### PR TITLE
refactor: extract database connection logic

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/config"
+	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/database"
 	"github.com/jackc/pgx/v5/pgconn"
-	_ "github.com/jackc/pgx/v5/stdlib"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -39,17 +39,12 @@ func main() {
 
 	cfg := config.Load()
 
-	db, err := sql.Open("pgx", cfg.DatabaseDSN())
+	db, err := database.Connect(ctx, cfg.DatabaseDSN())
 	if err != nil {
-		logger.Error("database open error", "error", err)
+		logger.Error("failed to connect to database", "error", err)
 		os.Exit(1)
 	}
 	defer db.Close()
-
-	if err := db.PingContext(ctx); err != nil {
-		logger.Error("database ping error", "error", err)
-		os.Exit(1)
-	}
 
 	// Crear usuario de prueba "admin"
 	testPasswordHash, err := bcrypt.GenerateFromPassword([]byte("admin123"), bcrypt.DefaultCost)

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -1,0 +1,25 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	// PostgreSQL driver
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Connect opens a connection to the PostgreSQL database and tests it.
+func Connect(ctx context.Context, dsn string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("error opening database: %w", err)
+	}
+
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("error pinging database: %w", err)
+	}
+
+	return db, nil
+}


### PR DESCRIPTION
### What changed
- Created a new package at `backend/internal/database/database.go`.
- Encapsulated the connection opening (`sql.Open`) and verification (`db.PingContext`) into a reusable `database.Connect()` function.
- Cleaned up `main.go` to consume this new function and moved the `pgx` driver import.

### Why it changed
Extracting the connection layer isolates this responsibility from `main.go`. This prepares the project for the future, allowing us to easily inject the `*sql.DB` connection into other packages, such as user or trip repositories.

### How it was tested
Tested manually since there are no automated tests for the database connection yet:
- [x] Started the local PostgreSQL database using `docker compose up -d`.
- [x] Ran the server manually with `go run ./backend/cmd/server`.
- [x] Verified in the terminal logs that the database connection and ping were successful on startup (`test user 'admin' ensured`).
- [x] Confirmed the API is still running by successfully hitting the `http://localhost:8080/health` endpoint.

Closes #4 
