### PR TITLE
feat: add domain interfaces and repository skeletons

### DIFF
--- a/backend/internal/domain/trip.go
+++ b/backend/internal/domain/trip.go
@@ -1,0 +1,26 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// Trip represents a ride published by a driver (equivalent to "Ride").
+type Trip struct {
+	ID             int64
+	DriverID       int64
+	Origin         string
+	Destination    string
+	DepartureDate  time.Time
+	AvailableSeats int
+	PricePerSeat   float64
+	Status         string
+	CreatedAt      time.Time
+}
+
+// TripRepository defines the contract for trip data access.
+type TripRepository interface {
+	Create(ctx context.Context, trip *Trip) error
+	GetByID(ctx context.Context, id int64) (*Trip, error)
+	ListOpenTrips(ctx context.Context) ([]*Trip, error)
+}

--- a/backend/internal/domain/trip_request.go
+++ b/backend/internal/domain/trip_request.go
@@ -1,0 +1,23 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// TripRequest represents a passenger's request to join a trip (equivalent to "Booking").
+type TripRequest struct {
+	ID          int64
+	TripID      int64
+	PassengerID int64
+	Status      string
+	Message     string
+	CreatedAt   time.Time
+}
+
+// TripRequestRepository defines the contract for trip requests data access.
+type TripRequestRepository interface {
+	Create(ctx context.Context, req *TripRequest) error
+	GetByTripID(ctx context.Context, tripID int64) ([]*TripRequest, error)
+	UpdateStatus(ctx context.Context, requestID int64, status string) error
+}

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -1,0 +1,22 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// User represents a registered account in the system.
+type User struct {
+	ID           int64
+	Username     string
+	Email        string
+	PasswordHash string
+	CreatedAt    time.Time
+}
+
+// UserRepository defines the contract for user data access.
+// This interface allows the service layer to be independent of SQL details.
+type UserRepository interface {
+	Create(ctx context.Context, user *User) error
+	GetByEmail(ctx context.Context, email string) (*User, error)
+}

--- a/backend/internal/repository/trip_repository.go
+++ b/backend/internal/repository/trip_repository.go
@@ -1,0 +1,34 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/domain"
+)
+
+// tripRepository implements domain.TripRepository for PostgreSQL.
+type tripRepository struct {
+	db *sql.DB
+}
+
+// NewTripRepository creates a new PostgreSQL trip repository.
+func NewTripRepository(db *sql.DB) domain.TripRepository {
+	return &tripRepository{db: db}
+}
+
+func (r *tripRepository) Create(ctx context.Context, trip *domain.Trip) error {
+	// TODO: Implement SQL INSERT logic
+	return errors.New("Create trip not implemented yet")
+}
+
+func (r *tripRepository) GetByID(ctx context.Context, id int64) (*domain.Trip, error) {
+	// TODO: Implement SQL SELECT logic
+	return nil, errors.New("GetByID not implemented yet")
+}
+
+func (r *tripRepository) ListOpenTrips(ctx context.Context) ([]*domain.Trip, error) {
+	// TODO: Implement SQL SELECT list logic
+	return nil, errors.New("ListOpenTrips not implemented yet")
+}

--- a/backend/internal/repository/trip_request_repository.go
+++ b/backend/internal/repository/trip_request_repository.go
@@ -1,0 +1,34 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/domain"
+)
+
+// tripRequestRepository implements domain.TripRequestRepository for PostgreSQL.
+type tripRequestRepository struct {
+	db *sql.DB
+}
+
+// NewTripRequestRepository creates a new PostgreSQL trip request repository.
+func NewTripRequestRepository(db *sql.DB) domain.TripRequestRepository {
+	return &tripRequestRepository{db: db}
+}
+
+func (r *tripRequestRepository) Create(ctx context.Context, req *domain.TripRequest) error {
+	// TODO: Implement SQL INSERT logic
+	return errors.New("Create trip request not implemented yet")
+}
+
+func (r *tripRequestRepository) GetByTripID(ctx context.Context, tripID int64) ([]*domain.TripRequest, error) {
+	// TODO: Implement SQL SELECT logic
+	return nil, errors.New("GetByTripID not implemented yet")
+}
+
+func (r *tripRequestRepository) UpdateStatus(ctx context.Context, requestID int64, status string) error {
+	// TODO: Implement SQL UPDATE logic
+	return errors.New("UpdateStatus not implemented yet")
+}

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -1,0 +1,29 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/isw2-unileon/proyect-scaffolding/backend/internal/domain"
+)
+
+// userRepository implements domain.UserRepository for PostgreSQL.
+type userRepository struct {
+	db *sql.DB
+}
+
+// NewUserRepository creates a new PostgreSQL user repository.
+func NewUserRepository(db *sql.DB) domain.UserRepository {
+	return &userRepository{db: db}
+}
+
+func (r *userRepository) Create(ctx context.Context, user *domain.User) error {
+	// TODO: Implement SQL INSERT logic
+	return errors.New("Create user not implemented yet")
+}
+
+func (r *userRepository) GetByEmail(ctx context.Context, email string) (*domain.User, error) {
+	// TODO: Implement SQL SELECT logic
+	return nil, errors.New("GetByEmail not implemented yet")
+}


### PR DESCRIPTION
### What changed
- Created the `internal/domain` package defining `User`, `Trip`, and `TripRequest` entities based on the domain model.
- Added repository interfaces (`UserRepository`, `TripRepository`, `TripRequestRepository`) to establish data access contracts.
- Created the `internal/repository` package with PostgreSQL specific implementations holding the `*sql.DB` connection.
- Added skeleton methods with `TODO`s for future SQL implementations.

### Why it changed
This implements a cleaner architecture by separating the business logic from the database access layer. Services will now depend on the domain interfaces rather than SQL details, making the code highly modular and easy to mock in future unit tests.

### How it was tested
Tested manually as these are structural skeletons:
- [x] Ran `go build ./...` to ensure all domain models, interfaces, and repository implementations compile correctly.
- [x] Ran `make lint` to verify code quality and documentation constraints.
- [x] Verified code structure matches the acceptance criteria (interfaces created, independent from SQL, documented in code).

Closes #7 
