### PR TITLE
feat(bookings): implement ride seat reduction on booking creation

### DIFF
--- a/backend/internal/bookings/handler.go
+++ b/backend/internal/bookings/handler.go
@@ -102,6 +102,18 @@ func (h *Handler) Create(c *gin.Context) {
 		return
 	}
 
+	// Reducimos los asientos disponibles en el viaje
+	ride.AvailableSeats -= req.SeatsReserved
+	if ride.AvailableSeats == 0 {
+		ride.Status = "full" // Si no quedan plazas, marcamos el viaje como lleno
+	}
+
+	if err := h.tripRepository.Update(ctx, ride); err != nil {
+		h.logger.Error("failed to update ride seats", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update ride"})
+		return
+	}
+
 	booking := &domain.Booking{
 		RideID:        req.RideID,
 		UserID:        userID,

--- a/backend/internal/domain/trip.go
+++ b/backend/internal/domain/trip.go
@@ -64,4 +64,5 @@ type TripRepository interface {
 	GetByID(ctx context.Context, id int64) (*Trip, error)
 	GetRideDetailsByID(ctx context.Context, id int64) (*RideDetails, error)
 	ListOpenTrips(ctx context.Context, filters TripFilters) ([]*Trip, error)
+	Update(ctx context.Context, trip *Trip) error
 }

--- a/backend/internal/repository/trip_repository.go
+++ b/backend/internal/repository/trip_repository.go
@@ -206,3 +206,32 @@ func (r *tripRepository) ListOpenTrips(ctx context.Context, filters domain.TripF
 
 	return trips, nil
 }
+
+func (r *tripRepository) Update(ctx context.Context, trip *domain.Trip) error {
+	res, err := r.db.ExecContext(
+		ctx,
+		`UPDATE ride
+		 SET origin = $1, destination = $2, departure_date = $3, available_seats = $4, price_per_seat = $5, status = $6, updated_at = CURRENT_TIMESTAMP
+		 WHERE id = $7`,
+		trip.Origin,
+		trip.Destination,
+		trip.DepartureDate,
+		trip.AvailableSeats,
+		trip.PricePerSeat,
+		trip.Status,
+		trip.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update trip: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check updated rows: %w", err)
+	}
+	if rows == 0 {
+		return domain.ErrRideNotFound
+	}
+
+	return nil
+}

--- a/backend/internal/reviews/handler_test.go
+++ b/backend/internal/reviews/handler_test.go
@@ -139,3 +139,7 @@ func (r *fakeReviewTripRepository) GetRideDetailsByID(_ context.Context, _ int64
 func (r *fakeReviewTripRepository) ListOpenTrips(_ context.Context, filters domain.TripFilters) ([]*domain.Trip, error) {
 	return nil, nil
 }
+
+func (r *fakeReviewTripRepository) Update(_ context.Context, _ *domain.Trip) error {
+	return nil
+}

--- a/backend/internal/rides/handler_test.go
+++ b/backend/internal/rides/handler_test.go
@@ -297,3 +297,7 @@ func (r *fakeTripRepository) ListOpenTrips(_ context.Context, filters domain.Tri
 		},
 	}, nil
 }
+
+func (r *fakeTripRepository) Update(_ context.Context, _ *domain.Trip) error {
+	return nil
+}


### PR DESCRIPTION
## Descripción
Este PR completa la primera historia de usuario del Sprint 4 de Reservas. Habilita el endpoint `POST /bookings` finalizando la lógica para guardar la reserva y decrementar los asientos disponibles del viaje asociado.

## Cambios principales
* **Dominio y Repositorio:** Creado e implementado el método `Update` en `trip_repository.go` para permitir la actualización parcial/total de un viaje tras ser modificado en memoria.
* **Handler de Reservas:** Se incorporó la lógica de deducción de asientos y el cambio de estado a `full` cuando las plazas llegan a `0`.
* **Tests:** Añadidas firmas faltantes de la interfaz en los fakes de test para asegurar que el pipeline CI/CD no rompa por errores de tipo.

## Tasks
- [x] Add `POST /bookings`
- [x] Require authentication
- [x] Receive `ride_id` and `seats_reserved`
- [x] Check available seats
- [x] Save booking in database
- [x] Reduce ride available seats
- [x] Return booking confirmation

## Acceptance Criteria
- [x] Logged users can reserve seats
- [x] Overbooking prevented
- [x] Booking stored correctly

## Definition of Done
- [x] Endpoint tested manually
- [x] Pull Request merged
