### PR TITLE
feat(rides): add endpoint to retrieve user's published rides

### DIFF
--- a/backend/internal/domain/trip.go
+++ b/backend/internal/domain/trip.go
@@ -22,6 +22,7 @@ type Trip struct {
 	CreatedAt      time.Time
 	AverageRating  float64
 	ReviewCount    int
+	BookingsCount  int
 }
 
 // RideDriver contains the public driver information returned in ride detail responses.
@@ -65,4 +66,5 @@ type TripRepository interface {
 	GetRideDetailsByID(ctx context.Context, id int64) (*RideDetails, error)
 	ListOpenTrips(ctx context.Context, filters TripFilters) ([]*Trip, error)
 	Update(ctx context.Context, trip *Trip) error
+	ListByDriverID(ctx context.Context, driverID int64) ([]*Trip, error)
 }

--- a/backend/internal/repository/trip_repository.go
+++ b/backend/internal/repository/trip_repository.go
@@ -139,9 +139,11 @@ func (r *tripRepository) ListOpenTrips(ctx context.Context, filters domain.TripF
 			rd.status,
 			rd.created_at,
 			COALESCE(ROUND(AVG(rv.rating)::numeric, 1), 0)::float8 AS average_rating,
-			COUNT(rv.id)::int AS review_count
+			COUNT(DISTINCT rv.id)::int AS review_count,
+			COUNT(DISTINCT b.id)::int AS bookings_count
 		FROM ride rd
 		LEFT JOIN reviews rv ON rv.ride_id = rd.id
+		LEFT JOIN bookings b ON b.ride_id = rd.id
 		WHERE rd.status IN ('open', 'completed')`
 	args := []any{}
 	conditions := []string{}
@@ -193,6 +195,7 @@ func (r *tripRepository) ListOpenTrips(ctx context.Context, filters domain.TripF
 			&trip.CreatedAt,
 			&trip.AverageRating,
 			&trip.ReviewCount,
+			&trip.BookingsCount,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan trip: %w", err)
 		}
@@ -234,4 +237,61 @@ func (r *tripRepository) Update(ctx context.Context, trip *domain.Trip) error {
 	}
 
 	return nil
+}
+
+func (r *tripRepository) ListByDriverID(ctx context.Context, driverID int64) ([]*domain.Trip, error) {
+	query := `SELECT
+			rd.id,
+			rd.driver_id,
+			rd.origin,
+			rd.destination,
+			rd.departure_date,
+			rd.available_seats,
+			rd.price_per_seat,
+			rd.status,
+			rd.created_at,
+			COALESCE(ROUND(AVG(rv.rating)::numeric, 1), 0)::float8 AS average_rating,
+			COUNT(DISTINCT rv.id)::int AS review_count,
+			COUNT(DISTINCT b.id)::int AS bookings_count
+		FROM ride rd
+		LEFT JOIN reviews rv ON rv.ride_id = rd.id
+		LEFT JOIN bookings b ON b.ride_id = rd.id
+		WHERE rd.driver_id = $1
+		GROUP BY rd.id
+		ORDER BY rd.departure_date DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, driverID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list driver trips: %w", err)
+	}
+	defer rows.Close()
+
+	trips := []*domain.Trip{}
+	for rows.Next() {
+		var trip domain.Trip
+		if err := rows.Scan(
+			&trip.ID,
+			&trip.DriverID,
+			&trip.Origin,
+			&trip.Destination,
+			&trip.DepartureDate,
+			&trip.AvailableSeats,
+			&trip.PricePerSeat,
+			&trip.Status,
+			&trip.CreatedAt,
+			&trip.AverageRating,
+			&trip.ReviewCount,
+			&trip.BookingsCount,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan driver trip: %w", err)
+		}
+
+		trips = append(trips, &trip)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read driver trips: %w", err)
+	}
+
+	return trips, nil
 }

--- a/backend/internal/reviews/handler_test.go
+++ b/backend/internal/reviews/handler_test.go
@@ -143,3 +143,7 @@ func (r *fakeReviewTripRepository) ListOpenTrips(_ context.Context, filters doma
 func (r *fakeReviewTripRepository) Update(_ context.Context, _ *domain.Trip) error {
 	return nil
 }
+
+func (r *fakeReviewTripRepository) ListByDriverID(_ context.Context, _ int64) ([]*domain.Trip, error) {
+	return nil, nil
+}

--- a/backend/internal/rides/handler.go
+++ b/backend/internal/rides/handler.go
@@ -230,3 +230,36 @@ func (h *Handler) ListRides(c *gin.Context) {
 		"rides": responses,
 	})
 }
+
+// ListCurrentUserRides handles the GET /me/rides endpoint to return rides published by the user.
+func (h *Handler) ListCurrentUserRides(c *gin.Context) {
+	userID := c.GetInt64("authUserID")
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), requestTimeout)
+	defer cancel()
+
+	trips, err := h.repo.ListByDriverID(ctx, userID)
+	if err != nil {
+		h.logger.Error("failed to find user trips", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch user rides"})
+		return
+	}
+
+	responses := make([]gin.H, 0, len(trips))
+	for _, t := range trips {
+		responses = append(responses, gin.H{
+			"id":             t.ID,
+			"origin":         t.Origin,
+			"destination":    t.Destination,
+			"departureDate":  t.DepartureDate.Format(time.RFC3339),
+			"availableSeats": t.AvailableSeats,
+			"price":          t.PricePerSeat,
+			"status":         t.Status,
+			"bookingsCount":  t.BookingsCount,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"rides": responses,
+	})
+}

--- a/backend/internal/rides/handler_test.go
+++ b/backend/internal/rides/handler_test.go
@@ -221,6 +221,37 @@ func TestGetRideByIDReturns404WhenMissing(t *testing.T) {
 	}
 }
 
+func TestListCurrentUserRidesRequiresAuthentication(t *testing.T) {
+	router, _ := setupRideRouter(t)
+
+	request := httptest.NewRequest(http.MethodGet, "/me/rides", nil)
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, response.Code)
+	}
+}
+
+func TestListCurrentUserRidesUsesAuthenticatedUserID(t *testing.T) {
+	router, repo := setupRideRouter(t)
+
+	request := httptest.NewRequest(http.MethodGet, "/me/rides", nil)
+	request.Header.Set("Authorization", "Bearer "+testToken(t, 42))
+	response := httptest.NewRecorder()
+
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d body=%s", http.StatusOK, response.Code, response.Body.String())
+	}
+
+	if repo.driverID != 42 {
+		t.Fatalf("expected driver id 42, got %d", repo.driverID)
+	}
+}
+
 func setupRideRouter(t *testing.T) (*gin.Engine, *fakeTripRepository) {
 	t.Helper()
 
@@ -231,6 +262,9 @@ func setupRideRouter(t *testing.T) (*gin.Engine, *fakeTripRepository) {
 	router := gin.New()
 	group := router.Group("/rides")
 	handler.RegisterRoutes(group, auth.Middleware("test-secret"))
+
+	meGroup := router.Group("/me", auth.Middleware("test-secret"))
+	meGroup.GET("/rides", handler.ListCurrentUserRides)
 
 	return router, repo
 }
@@ -258,6 +292,7 @@ type fakeTripRepository struct {
 	detail    *domain.RideDetails
 	detailErr error
 	filters   domain.TripFilters
+	driverID  int64
 }
 
 func (r *fakeTripRepository) Create(_ context.Context, trip *domain.Trip) error {
@@ -266,6 +301,24 @@ func (r *fakeTripRepository) Create(_ context.Context, trip *domain.Trip) error 
 	r.created = trip
 
 	return nil
+}
+
+func (r *fakeTripRepository) ListByDriverID(_ context.Context, driverID int64) ([]*domain.Trip, error) {
+	r.driverID = driverID
+	return []*domain.Trip{
+		{
+			ID:             10,
+			DriverID:       driverID,
+			Origin:         "Madrid",
+			Destination:    "Barcelona",
+			DepartureDate:  time.Date(2099, 5, 20, 8, 30, 0, 0, time.UTC),
+			AvailableSeats: 3,
+			PricePerSeat:   12.50,
+			Status:         "open",
+			CreatedAt:      time.Now(),
+			BookingsCount:  2,
+		},
+	}, nil
 }
 
 func (r *fakeTripRepository) GetByID(_ context.Context, _ int64) (*domain.Trip, error) {

--- a/backend/internal/shared/router/router.go
+++ b/backend/internal/shared/router/router.go
@@ -53,9 +53,11 @@ func New(dependencies Dependencies) *gin.Engine {
 
 	apiMeGroup := api.Group("/me", auth.Middleware(dependencies.JWTSecret))
 	apiMeGroup.GET("/bookings", dependencies.BookingHandler.ListCurrentUser)
+	apiMeGroup.GET("/rides", dependencies.RideHandler.ListCurrentUserRides)
 
 	meGroup := engine.Group("/me", auth.Middleware(dependencies.JWTSecret))
 	meGroup.GET("/bookings", dependencies.BookingHandler.ListCurrentUser)
+	meGroup.GET("/rides", dependencies.RideHandler.ListCurrentUserRides)
 
 	// Rutas públicas para listar los viajes (rides)
 	api.GET("/rides", dependencies.RideHandler.ListRides)


### PR DESCRIPTION
## Descripción
Este PR introduce la capacidad para que un conductor autenticado pueda recuperar exclusivamente los viajes que él ha publicado, implementando el endpoint `GET /me/rides`.

## Cambios principales
* **Dominio y Repositorio:** El `TripRepository` incluye la función `ListByDriverID` con soporte para contar el número de asientos reservados/bookings desde la base de datos gracias a un `LEFT JOIN` con `COUNT(DISTINCT)`.
* **Seguridad:** Los viajes solo se entregan si coinciden con el `authUserID` del token JWT proporcionado, garantizando que el usuario solo pueda ver sus viajes.
* **Respuesta Limpia:** La respuesta incluye toda la información valiosa requerida para su futuro uso en el dashboard del frontend (`availableSeats`, `bookingsCount`, etc.).

## Tasks
- [x] Add `GET /me/rides`
- [x] Require authentication
- [x] Return rides published by logged user
- [x] Include bookings count
- [x] Include available seats

## Acceptance Criteria
- [x] Users can see own published rides
- [x] Useful dashboard data returned
- [x] Only owner rides included

## Definition of Done
- [x] Tested locally
- [x] Merged to main
